### PR TITLE
Bugfix: Get the complete list of available Perls

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
     - perlbrew
 
 - name: Get available perlbrew Perls
-  command: "{{ perlbrew_bin }} available"
+  command: "{{ perlbrew_bin }} available --all"
   register: perlbrew_available_output
   tags:
     - perlbrew


### PR DESCRIPTION
With `perlbrew available` only the latest patch-levels of all Perl versions are shown. That means that your playbook starts failing as soon as a new patch version of your Perl versions is released.
With `perlbrew available --all` the complete list of Perls is fetched.